### PR TITLE
docs: fix simple typo, recusion -> recursion

### DIFF
--- a/docs/leetcode/python/326._power_of_three.md
+++ b/docs/leetcode/python/326._power_of_three.md
@@ -28,7 +28,7 @@ class Solution(object):
        
 ```
 
-有一个follow up，可否不用 loop/recusion
+有一个follow up，可否不用 loop/recursion
 
 看到了取巧的办法，因为是Given an integer,是有范围的（<2147483648),存在能输入的最大的3的幂次，即 3^19=1162261467。
 


### PR DESCRIPTION
There is a small typo in docs/leetcode/python/326._power_of_three.md.

Should read `recursion` rather than `recusion`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md